### PR TITLE
Fix for recent emcc SDK.

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -12,19 +12,16 @@ HTML_TEMPLATE = src/web/index_template.html
 WASMFLAGS = \
 	-O3 \
 	--memory-init-file 1 \
-	--llvm-lto 3 \
-	--llvm-opts 3 \
-	--js-opts 1 \
 	--closure 1 \
 	--shell-file $(HTML_TEMPLATE) \
 	-s ENVIRONMENT=web \
 	-s ALLOW_MEMORY_GROWTH=1 \
 	-s AGGRESSIVE_VARIABLE_ELIMINATION=1 \
 	-s ABORTING_MALLOC=1 \
+	-s "EXPORTED_FUNCTIONS=['_main', '_malloc']" \
 	-s EXIT_RUNTIME=0 \
 	-s NO_FILESYSTEM=1 \
-	-s DISABLE_EXCEPTION_CATCHING=2 \
-	-s BINARYEN_TRAP_MODE=\'allow\'
+	-s DISABLE_EXCEPTION_CATCHING=2 
 	# --bind \
 	#-s 'EXTRA_EXPORTED_RUNTIME_METHODS=["UTF8ToString"]'
 
@@ -32,7 +29,7 @@ build/index.html: src/driver.o lib/window.o lib/canvas.o
 	$(CC) $(WASMFLAGS) lib/window.o lib/canvas.o src/driver.o -o build/index.html
 	
 src/driver.o: src/driver.c
-	$(CC) $(CFLAGS) -I $(HEADERS_FOLDER)/ src/driver.c -o src/driver.o
+	$(CC) $(CFLAGS) -I $(HEADERS_FOLDER)/ -c -o src/driver.o src/driver.c
 
 lib/window.o: lib/window.c
 


### PR DESCRIPTION
Emscripten has since switched to using LLVM and removed the old fastcomp compiler.
As a result, some commands were deprecated.
The makefile also had some mistakes that prevented compilation. (For example _malloc)